### PR TITLE
Sitemap improvements

### DIFF
--- a/AardvarkSeo/Sitemaps/Sitemap.php
+++ b/AardvarkSeo/Sitemaps/Sitemap.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Addons\AardvarkSeo\Sitemaps;
 
+use Statamic\Addons\AardvarkSeo\Sitemaps\SitemapItem;
 use Statamic\API\Collection;
 use Statamic\API\Config;
 use Statamic\API\Page;
@@ -49,18 +50,24 @@ class Sitemap
             return $item->published() && !$item->get('page_no_index');
         });
 
-        $sitemapData = collect($items)->map(function ($item) {
-            $data = collect($item->data());
-
-            $data = [
-                'url' => $item->absoluteURL(),
-                'changefreq' => $data->get('sitemap_changefreq'),
-                'priority' => $data->get('sitemap_priority'),
-                'lastmod' => $item->lastModified()->format('Y-m-d\TH:i:sP'),
-            ];
-
-            return $data;
+        $sitemap_items = collect($items)->map(function ($item) {
+            return new SitemapItem($item);
         });
+
+        $sitemapData = $sitemap_items
+            ->unique(function ($item) {
+                return $item->getUrl();
+            })
+            ->map(function ($item) {
+                $data = [
+                    'url' => $item->getUrl(),
+                    'changefreq' => $item->getChangeFreq(),
+                    'priority' => $item->getPriority(),
+                    'lastmod' => $item->getFormattedLastMod(),
+                ];
+
+                return $data;
+            });
 
         return $sitemapData->all();
     }

--- a/AardvarkSeo/Sitemaps/Sitemap.php
+++ b/AardvarkSeo/Sitemaps/Sitemap.php
@@ -46,7 +46,7 @@ class Sitemap
         }
 
         $items = $items->filter(function ($item) {
-            return $item->published();
+            return $item->published() && !$item->get('page_no_index');
         });
 
         $sitemapData = collect($items)->map(function ($item) {

--- a/AardvarkSeo/Sitemaps/SitemapItem.php
+++ b/AardvarkSeo/Sitemaps/SitemapItem.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Statamic\Addons\AardvarkSeo\Sitemaps;
+
+class SitemapItem
+{
+    const DEFAULT_CHANGEFREQ = 'daily';
+    const DEFAULT_PRIORITY = '0.5';
+
+    /**
+     * Create a new sitemap item
+     *
+     * @param \Statamic\Data\Content\Content $content
+     */
+    public function __construct(\Statamic\Data\Content\Content $content)
+    {
+        $this->data_object = $content;
+        $this->data = collect($this->data_object->data());
+    }
+
+    /**
+     * Get the url of the current item
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        $item = $this->data_object;
+        return $item->get('canonical_url') ?: $item->absoluteUrl();
+    }
+
+    /**
+     * Get a formatted version of the last modified attribute
+     *
+     * @return string
+     */
+    public function getFormattedLastMod()
+    {
+        return $this->data_object->lastModified()->format('Y-m-d\TH:i:sP');
+    }
+
+    /**
+     * Return the changefrequency with a fallback
+     *
+     * @return string
+     */
+    public function getChangeFreq()
+    {
+        return $this->data->get('sitemap_changefreq') ?: self::DEFAULT_CHANGEFREQ;
+    }
+
+    /**
+     * Return the priority with a fallback
+     *
+     * @return string
+     */
+    public function getPriority()
+    {
+        return $this->data->get('sitemap_priority') ?: self::DEFAULT_PRIORITY;
+    }
+}


### PR DESCRIPTION
- Remove non-indexed pages from the sitemap
- Where possible use the `canonical_url` attribute in the sitemap
- Remove duplicate links from sitemaps (As more than one page can have the same canonical url)