### PR TITLE
Content defaults

### DIFF
--- a/AardvarkSeo/AardvarkSeoListener.php
+++ b/AardvarkSeo/AardvarkSeoListener.php
@@ -51,7 +51,7 @@ class AardvarkSeoListener extends Listener
 
         $seo_section->add(function ($item) {
             $item->add(Nav::item('General')->route('aardvark-seo.general'));
-            $item->add(Nav::item('Content Defaults')->route('aardvark-seo.defaults'));
+            $item->add(Nav::item('Content defaults')->route('aardvark-seo.defaults'));
             $item->add(Nav::item('Marketing')->route('aardvark-seo.marketing'));
             $item->add(Nav::item('Social')->route('aardvark-seo.social'));
             $item->add(Nav::item('Redirects')->route('aardvark-seo.redirects')->badge('BETA'));

--- a/AardvarkSeo/AardvarkSeoListener.php
+++ b/AardvarkSeo/AardvarkSeoListener.php
@@ -51,6 +51,7 @@ class AardvarkSeoListener extends Listener
 
         $seo_section->add(function ($item) {
             $item->add(Nav::item('General')->route('aardvark-seo.general'));
+            $item->add(Nav::item('Content Defaults')->route('aardvark-seo.defaults'));
             $item->add(Nav::item('Marketing')->route('aardvark-seo.marketing'));
             $item->add(Nav::item('Social')->route('aardvark-seo.social'));
             $item->add(Nav::item('Redirects')->route('aardvark-seo.redirects')->badge('BETA'));

--- a/AardvarkSeo/AardvarkSeoListener.php
+++ b/AardvarkSeo/AardvarkSeoListener.php
@@ -6,11 +6,13 @@ use Stataimc\Events\Event;
 use Statamic\Addons\AardvarkSeo\Controllers\Controller as AardvarkController;
 use Statamic\Addons\AardvarkSeo\Controllers\RedirectsController;
 use Statamic\Addons\AardvarkSeo\Controllers\SitemapController;
+use Statamic\Addons\AardvarkSeo\Controllers\DefaultsController;
 use Statamic\Addons\AardvarkSeo\Sitemaps\Sitemap;
 use Statamic\Addons\AardvarkSeo\Traits\TransformsAssetsFieldtypes;
 use Statamic\API\File;
 use Statamic\API\Nav;
 use Statamic\API\YAML;
+use Statamic\API\Config;
 use Statamic\Extend\Listener;
 
 /**
@@ -82,6 +84,29 @@ class AardvarkSeoListener extends Listener
         $fields = YAML::parse($seoFieldsetContents)['fields'];
         $assetContainer = $this->getConfig('asset_container') ?: 'main';
         $processedFields = $this->transformAssetsFields($fields, $assetContainer);
+
+        $ctx = [
+            'page_object' => $event->data,
+        ];
+
+        switch ($event->type) {
+            case 'entry':
+                $collection = $event->data->collection();
+                $ctx['collection'] = $collection->path();
+                break;
+            case 'term':
+                $taxonomy = $event->data->taxonomy();
+                $ctx['taxonomy'] = $taxonomy->path();
+                break;
+        }
+
+        $defaults = collect($this->getDefaults(collect($ctx), Config::getDefaultLocale()));
+        $localisedDefaults = $defaults->merge($this->getDefaults(collect($ctx), site_locale()));
+
+        $processedFields = collect($processedFields)->map(function ($field, $name) use ($localisedDefaults) {
+            $field['placeholder'] = $localisedDefaults->get($name, '');
+            return $field;
+        });
 
         $fieldsetSections = $fieldset->sections();
 
@@ -189,6 +214,19 @@ class AardvarkSeoListener extends Listener
         $storage = $this->storage->getYAML(RedirectsController::STORAGE_KEY);
         $isEnabled = collect($storage)->get($requiredAttr);
         return $isEnabled;
+    }
+
+    /**
+     * Forward a call to the defaults controller getDefaults method
+     *
+     * @param array $ctx
+     * @param string $locale
+     *
+     * @return array
+     */
+    private function getDefaults($ctx, $locale)
+    {
+        return DefaultsController::getDefaults($ctx, $locale);
     }
 
     /**

--- a/AardvarkSeo/AardvarkSeoTags.php
+++ b/AardvarkSeo/AardvarkSeoTags.php
@@ -3,6 +3,7 @@
 namespace Statamic\Addons\AardvarkSeo;
 
 use Statamic\Addons\AardvarkSeo\Controllers\AardvarkSeoController;
+use Statamic\Addons\AardvarkSeo\Controllers\DefaultsController;
 use Statamic\API\Config;
 use Statamic\API\Collection;
 use Statamic\API\Data;
@@ -188,28 +189,15 @@ class AardvarkSeoTags extends Tags
     }
 
     /**
-     * Return the default SEO values for the data described
-     * in the current context
+     * Forward a call to the defaults controller getDefaults method
      *
-     * @param array $context
+     * @param array $ctx
+     * @param string $locale
      *
      * @return array
      */
     private function getDefaults($ctx, $locale)
     {
-        $class = (new \ReflectionClass($ctx->get('page_object')))->getShortName();
-        switch ($class) {
-            case 'Entry':
-                $object = Collection::whereHandle($ctx->get('collection', ''));
-                break;
-            case 'Term':
-                $object = Taxonomy::whereHandle($ctx->get('taxonomy', ''));
-                break;
-            case 'Page':
-                $object = PageFolder::whereHandle('/') ?: PageFolder::create();
-                $object->path('/');
-                break;
-        }
-        return $object->get('aardvark_' . $locale, []);
+        return DefaultsController::getDefaults($ctx, $locale);
     }
 }

--- a/AardvarkSeo/AardvarkSeoTags.php
+++ b/AardvarkSeo/AardvarkSeoTags.php
@@ -198,7 +198,7 @@ class AardvarkSeoTags extends Tags
     private function getDefaults($ctx, $locale)
     {
         $class = (new \ReflectionClass($ctx->get('page_object')))->getShortName();
-        switch($class) {
+        switch ($class) {
             case 'Entry':
                 $object = Collection::whereHandle($ctx->get('collection', ''));
                 break;
@@ -209,7 +209,7 @@ class AardvarkSeoTags extends Tags
                 $object = PageFolder::whereHandle('/') ?: PageFolder::create();
                 $object->path('/');
                 break;
-        };
+        }
         return $object->get('aardvark_' . $locale, []);
     }
 }

--- a/AardvarkSeo/Controllers/Controller.php
+++ b/AardvarkSeo/Controllers/Controller.php
@@ -88,7 +88,7 @@ class Controller extends StatamicController
      * @param string $message The message to put inside the success box
      * @param string $route   The route to redirect back to
      */
-    private function successResponse($route)
+    protected function successResponse($route)
     {
         $message = 'SEO Settings Updated!';
 

--- a/AardvarkSeo/Controllers/DefaultsController.php
+++ b/AardvarkSeo/Controllers/DefaultsController.php
@@ -31,7 +31,7 @@ class DefaultsController extends Controller
     public function single(Request $request, $type, $slug)
     {
         $object = $this->getDataObject($type, $slug);
-        switch($type) {
+        switch ($type) {
             case 'collections':
                 $title = 'Collection: ' . $object->title();
                 break;
@@ -81,7 +81,7 @@ class DefaultsController extends Controller
         $object->set('aardvark_' . $request->locale, $data);
         $object->save();
 
-        switch($type) {
+        switch ($type) {
             case 'collections':
                 event(new CollectionSaved($object));
                 break;
@@ -107,7 +107,7 @@ class DefaultsController extends Controller
      */
     private function getDataObject($type, $slug)
     {
-        switch($type) {
+        switch ($type) {
             case 'collections':
                 $object = Collection::whereHandle($slug);
                 break;
@@ -134,14 +134,14 @@ class DefaultsController extends Controller
                 [
                     'count' => Page::all()->count(),
                     'slug' => 'pages',
-                    'title' => 'Pages'
+                    'title' => 'Pages',
                 ],
             ]),
         ];
 
         $collections = [
             'title' => 'Collections',
-            'items' => Collection::all()->map(function($collection) {
+            'items' => Collection::all()->map(function ($collection) {
                 return [
                     'count' => $collection->count(),
                     'slug' => $collection->path(),
@@ -152,7 +152,7 @@ class DefaultsController extends Controller
 
         $taxonomies = [
             'title' => 'Taxonomies',
-            'items' => Taxonomy::all()->map(function($taxonomy) {
+            'items' => Taxonomy::all()->map(function ($taxonomy) {
                 return [
                     'count' => $taxonomy->count(),
                     'slug' => $taxonomy->path(),
@@ -164,7 +164,7 @@ class DefaultsController extends Controller
         return compact('pages', 'collections', 'taxonomies');
     }
 
-     /**
+    /**
      * Get locales and their links
      *
      * @return array
@@ -181,12 +181,12 @@ class DefaultsController extends Controller
             }
 
             $locales[] = [
-                'name'        => $locale,
-                'label'       => Config::getLocaleName($locale),
-                'url'         => $url,
-                'is_active'   => $locale === app('request')->query('locale', Config::getDefaultLocale()),
+                'name' => $locale,
+                'label' => Config::getLocaleName($locale),
+                'url' => $url,
+                'is_active' => $locale === app('request')->query('locale', Config::getDefaultLocale()),
                 'has_content' => true,
-                'is_published'=> true
+                'is_published' => true,
             ];
         }
 

--- a/AardvarkSeo/Controllers/DefaultsController.php
+++ b/AardvarkSeo/Controllers/DefaultsController.php
@@ -2,14 +2,24 @@
 
 namespace Statamic\Addons\AardvarkSeo\Controllers;
 
+use Illuminate\Http\Request;
+use Statamic\Events\Data\ContentSaved;
 use Statamic\API\Collection;
 use Statamic\API\Entry;
 use Statamic\API\Page;
+use Statamic\API\PageFolder;
 use Statamic\API\Taxonomy;
 use Statamic\API\Term;
+use Statamic\API\Config;
+use Statamic\Events\Data\CollectionSaved;
+use Statamic\Events\Data\TaxonomySaved;
+use Statamic\Events\Data\SettingsSaved;
+use Statamic\CP\Publish\ProcessesFields;
 
 class DefaultsController extends Controller
 {
+    use ProcessesFields;
+
     public function index()
     {
         return $this->view('defaults_index', [
@@ -18,6 +28,104 @@ class DefaultsController extends Controller
         ]);
     }
 
+    public function single(Request $request, $type, $slug)
+    {
+        $object = $this->getDataObject($type, $slug);
+        switch($type) {
+            case 'collections':
+                $title = 'Collection: ' . $object->title();
+                break;
+            case 'taxonomies':
+                $title = 'Taxonomy: ' . $object->title();
+                break;
+            case 'pages':
+                $title = 'Pages';
+                break;
+            default:
+                $title = 'None';
+        }
+
+        $fieldset = $this->createAddonFieldset('defaults');
+
+        $stored_data = $object->get('aardvark_' . $request->locale) ?: $object->get('aardvark_' . Config::getDefaultLocale());
+
+        $data = $this->preProcessWithBlankFields(
+            $fieldset,
+            $stored_data
+        );
+
+        return $this->view('defaults_single', [
+            'data' => $data,
+            'fieldset' => $fieldset->toPublishArray(),
+            'locale' => $request->query('locale', site_locale()),
+            'locales' => $this->getLocales(),
+            'slug' => $slug,
+            'submitUrl' => route('aardvark-seo.defaults.save', [$type, $slug]),
+            'title' => $title,
+            'type' => $type,
+        ]);
+    }
+
+    /**
+     * Save the current form into the aardvark defaults section
+     * of the data object
+     *
+     * @param Request $request
+     * @param string $type
+     * @param string $slug
+     */
+    public function save(Request $request, $type, $slug)
+    {
+        $data = $this->processFields($this->createAddonFieldset($request->fieldset), $request->fields);
+        $object = $this->getDataObject($type, $slug);
+        $object->set('aardvark_' . $request->locale, $data);
+        $object->save();
+
+        switch($type) {
+            case 'collections':
+                event(new CollectionSaved($object));
+                break;
+            case 'taxonomies':
+                event(new TaxonomySaved($object));
+                break;
+            case 'pages':
+                // In the absence of a PagesFolderSaved event use the settings saved event
+                event(new SettingsSaved($object->path(), $object->data()));
+                break;
+        }
+
+        return $this->successResponse('aardvark-seo.defaults');
+    }
+
+    /**
+     * Get the data object for which this request pertains to
+     *
+     * @param string $type
+     * @param string $slug
+     *
+     * @return Statamic\Data\DataFolder
+     */
+    private function getDataObject($type, $slug)
+    {
+        switch($type) {
+            case 'collections':
+                $object = Collection::whereHandle($slug);
+                break;
+            case 'taxonomies':
+                $object = Taxonomy::whereHandle($slug);
+                break;
+            case 'pages':
+                $object = PageFolder::whereHandle('/') ?: PageFolder::create();
+                $object->path('/');
+        }
+        return $object;
+    }
+
+    /**
+     * Return a list of all possible content types for which we can set the defaults
+     *
+     * @return array
+     */
     private function getContentTypes()
     {
         $pages = [
@@ -54,5 +162,34 @@ class DefaultsController extends Controller
         ];
 
         return compact('pages', 'collections', 'taxonomies');
+    }
+
+     /**
+     * Get locales and their links
+     *
+     * @return array
+     */
+    protected function getLocales()
+    {
+        $locales = [];
+
+        foreach (Config::getLocales() as $locale) {
+            $url = app('request')->url();
+
+            if ($locale !== Config::getDefaultLocale()) {
+                $url .= '?locale=' . $locale;
+            }
+
+            $locales[] = [
+                'name'        => $locale,
+                'label'       => Config::getLocaleName($locale),
+                'url'         => $url,
+                'is_active'   => $locale === app('request')->query('locale', Config::getDefaultLocale()),
+                'has_content' => true,
+                'is_published'=> true
+            ];
+        }
+
+        return $locales;
     }
 }

--- a/AardvarkSeo/Controllers/DefaultsController.php
+++ b/AardvarkSeo/Controllers/DefaultsController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Statamic\Addons\AardvarkSeo\Controllers;
+
+use Statamic\API\Collection;
+use Statamic\API\Entry;
+use Statamic\API\Page;
+use Statamic\API\Taxonomy;
+use Statamic\API\Term;
+
+class DefaultsController extends Controller
+{
+    public function index()
+    {
+        return $this->view('defaults_index', [
+            'title' => 'Content defaults',
+            'contentTypes' => $this->getContentTypes(),
+        ]);
+    }
+
+    private function getContentTypes()
+    {
+        $pages = [
+            'title' => 'Pages',
+            'items' => collect([
+                [
+                    'count' => Page::all()->count(),
+                    'slug' => 'pages',
+                    'title' => 'Pages'
+                ],
+            ]),
+        ];
+
+        $collections = [
+            'title' => 'Collections',
+            'items' => Collection::all()->map(function($collection) {
+                return [
+                    'count' => $collection->count(),
+                    'slug' => $collection->path(),
+                    'title' => $collection->title(),
+                ];
+            }),
+        ];
+
+        $taxonomies = [
+            'title' => 'Taxonomies',
+            'items' => Taxonomy::all()->map(function($taxonomy) {
+                return [
+                    'count' => $taxonomy->count(),
+                    'slug' => $taxonomy->path(),
+                    'title' => $taxonomy->title(),
+                ];
+            }),
+        ];
+
+        return compact('pages', 'collections', 'taxonomies');
+    }
+}

--- a/AardvarkSeo/Controllers/DefaultsController.php
+++ b/AardvarkSeo/Controllers/DefaultsController.php
@@ -192,4 +192,31 @@ class DefaultsController extends Controller
 
         return $locales;
     }
+
+    /**
+     * Return the default SEO values for the data described
+     * in the current context
+     *
+     * @param array $context
+     * @param string $locale
+     *
+     * @return array
+     */
+    public static function getDefaults($ctx, $locale)
+    {
+        $class = (new \ReflectionClass($ctx->get('page_object')))->getShortName();
+        switch ($class) {
+            case 'Entry':
+                $object = Collection::whereHandle($ctx->get('collection', ''));
+                break;
+            case 'Term':
+                $object = Taxonomy::whereHandle($ctx->get('taxonomy', ''));
+                break;
+            case 'Page':
+                $object = PageFolder::whereHandle('/') ?: PageFolder::create();
+                $object->path('/');
+                break;
+        }
+        return $object->get('aardvark_' . $locale, []);
+    }
 }

--- a/AardvarkSeo/fieldsets/defaults.yaml
+++ b/AardvarkSeo/fieldsets/defaults.yaml
@@ -21,32 +21,6 @@ fields:
       use_meta_keywords:
         - true
     localizable: true
-  meta_preview:
-    display: Google search preview
-    type: aardvark_seo.meta_preview
-    localizable: true
-  urls_section:
-    type: section
-    display: URL Options
-  canonical_url:
-    display: 'Canonical URL'
-    type: text
-    localizable: true
-  localized_urls:
-    display: Alternate URLs
-    instructions: Create a list of urls for alternate locales
-    type: grid
-    add_row: Add a new locale
-    fields:
-      locale:
-        type: text
-        width: 30
-        placeholder: 'fr-fr'
-      url:
-        display: URL
-        type: text
-        placeholder: 'mysite.com/fr/'
-    localizable: true
   indexing_section:
     type: section
     display: Indexing and Sitemaps
@@ -61,40 +35,6 @@ fields:
     display: 'Nofollow links'
     instructions: 'Enabling this will prevent site crawlers from following on-page links'
     width: 50
-    localizable: true
-  sitemap_priority:
-    type: select
-    display: Sitemap priority
-    instructions: Set the priorty of this page in the sitemap (1.0 being the most important)
-    default: '0.5'
-    width: 50
-    options:
-      - '0.0'
-      - '0.1'
-      - '0.2'
-      - '0.3'
-      - '0.4'
-      - '0.5'
-      - '0.6'
-      - '0.7'
-      - '0.8'
-      - '0.9'
-      - '1.0'
-    localizable: true
-  sitemap_changefreq:
-    type: select
-    display: Change frequency
-    instructions: Set how often this page will change for the sitemap
-    width: 50
-    default: 'daily'
-    options:
-      - "always"
-      - "hourly"
-      - "daily"
-      - "weekly"
-      - "monthly"
-      - "yearly"
-      - "never"
     localizable: true
   share_section_facebook:
     type: section

--- a/AardvarkSeo/resources/assets/js/fieldtype.js
+++ b/AardvarkSeo/resources/assets/js/fieldtype.js
@@ -9,7 +9,7 @@ const MetaAnalysis = {
 
   methods: {
     handleKeyUp: function(e) {
-      this.contentLength = this.data.length;
+      this.contentLength = this.data && this.data.length;
       this.validation = this._getValidation(this.data.length);
     }
   }
@@ -95,7 +95,7 @@ Vue.component("aardvark_seo-valid_meta_title-fieldtype", {
     },
     _generateDefaultTitle() {
       const parentTitle = this.$parent.$parent.data.title || '';
-      return `${parentTitle} ${this.title_separator} ${this.site_name}`;
+      return this.config.placeholder || `${parentTitle} ${this.title_separator} ${this.site_name}`;
     }
   }
 });
@@ -112,7 +112,7 @@ Vue.component("aardvark_seo-valid_meta_description-fieldtype", {
   data: function() {
     return {
       placeholder:
-        "No meta description has been set for this page, search engines will use a relevent body of text from the page content instead."
+        this.config.placeholder || "No meta description has been set for this page, search engines will use a relevent body of text from the page content instead."
     };
   },
 

--- a/AardvarkSeo/resources/views/defaults_index.blade.php
+++ b/AardvarkSeo/resources/views/defaults_index.blade.php
@@ -1,0 +1,35 @@
+@extends('layout')
+@section('content-class', 'publishing')
+
+@section('content')
+
+    <div class="w-full px-1 md:px-3">
+        <h1>{{ $title }}</h1>
+        @foreach($contentTypes as $type => $content)
+
+        <h2>{{ $content['title'] }}</h2>
+
+        <div class="card flush">
+            <div class="dossier-table-wrapper">
+                    <table class="dossier">
+                        <tbody>
+                            @foreach($content['items'] as $item)
+                                <tr>
+                                    <td class="cell-title first-cell">
+                                        <div class="stat">
+                                            <span class="icon icon-documents"></span>
+                                            {{ $item['count'] }}
+                                        </div>
+                                        <a href="{{ route('aardvark-seo.defaults') }}/{{ $type }}/{{ $item['slug'] }}">{{ $item['title'] }}</a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+        </div>
+
+        @endforeach
+    </div>
+
+@endsection

--- a/AardvarkSeo/resources/views/defaults_single.blade.php
+++ b/AardvarkSeo/resources/views/defaults_single.blade.php
@@ -1,0 +1,24 @@
+@extends('layout')
+@section('content-class', 'publishing')
+
+@section('content')
+
+    <script>
+        Statamic.Publish = {
+            contentData: {!! json_encode($data) !!},
+            fieldset: {!! json_encode($fieldset) !!},
+            locale: '{!! $locale !!}'
+        };
+    </script>
+
+    <publish
+        title="{{ $title }}"
+        submit-url="{{ $submitUrl }}"
+        content-type="global"
+        :meta-fields="false"
+        :is-new="false"
+        locale="{{ $locale }}"
+        locales="{{ json_encode($locales) }}"
+    ></publish>
+
+@endsection

--- a/AardvarkSeo/routes.yaml
+++ b/AardvarkSeo/routes.yaml
@@ -5,6 +5,15 @@ routes:
   general:
     uses: getGeneralForm
     as: aardvark-seo.general
+  defaults:
+    uses: DefaultsController@index
+    as: aardvark-seo.defaults
+  defaults/{content}/{slug}:
+    uses: DefaultsController@single
+    as: aardvark-seo.defaults.single
+  post@defaults/{content}/{slug}:
+    uses: DefaultsController@save
+    as: aardvark-seo.defaults.save
   marketing:
     uses: getMarketingForm
     as: aardvark-seo.marketing

--- a/AardvarkSeo/routes.yaml
+++ b/AardvarkSeo/routes.yaml
@@ -8,10 +8,10 @@ routes:
   defaults:
     uses: DefaultsController@index
     as: aardvark-seo.defaults
-  defaults/{content}/{slug}:
+  defaults/{type}/{slug}:
     uses: DefaultsController@single
     as: aardvark-seo.defaults.single
-  post@defaults/{content}/{slug}:
+  post@defaults/{type}/{slug}:
     uses: DefaultsController@save
     as: aardvark-seo.defaults.save
   marketing:

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -79,3 +79,6 @@ The social media data can be accessed on the frontend through the `{{ aardvark-s
 
 ## Localization / Hreflang
 Aardvark SEO will automatically generate a list of `<link rel="alternate" hreflang="x">` tags for sites that are running multiple locales. Additionally you can manually configure alternate urls using the 'Alternate URLs' table in the on-page SEO settings.
+
+## Content defaults
+You can set default SEO options on a per-content option. For example, SEO options can be set at the collection level, allowing for section-specific values for fields like the OpenGraph share image etc. To control the defaults head to SEO > Content Defaults in the menu and click through to each collection / taxonomy individually.


### PR DESCRIPTION
- Adds the option to set default values for the Aardvark fields at a `Collection`, `Taxonomy` or `Pages` level
- Defaults can be localised

