### PR TITLE
Whitelist the "Page" query parameter for use in canonical URLs

### DIFF
--- a/AardvarkSeo/AardvarkSeoTags.php
+++ b/AardvarkSeo/AardvarkSeoTags.php
@@ -64,6 +64,23 @@ class AardvarkSeoTags extends Tags
     }
 
     /**
+     * Return a generated canonical URL - this should contain pagination vars
+     * if any are set
+     *
+     * @return string
+     */
+    public function generatedCanonical()
+    {
+        $data = collect($this->getData());
+        $vars = $data->get('get');
+        $current_url = $data->get('current_url');
+        if ($vars && $page = collect($vars)->get('page')) {
+            $current_url .= '?page=' . urlencode($page);
+        }
+        return $current_url;
+    }
+
+    /**
      * Return a template file from this addon.
      *
      * @param string $name The name of the html view file

--- a/AardvarkSeo/resources/views/tags/aardvark-seo-head.html
+++ b/AardvarkSeo/resources/views/tags/aardvark-seo-head.html
@@ -20,10 +20,18 @@
 {{# General default meta tags #}}
 <title>{{ meta_title or calculated_title }}</title>
 <meta name="description" content="{{ meta_description }}">
+
+{{ if canonical_url }}
+<link rel="canonical" href="{{ canonical_url }}">
+<meta property="og:url" content="{{ canonical_url }}">
+{{ else }}
+<link rel="canonical" href="{{ aardvark_seo:generated_canonical }}">
+<meta property="og:url" content="{{ aardvark_seo:generated_canonical }}">
+{{ /if }}
+
 {{ if use_meta_keywords }}
 <meta name="keywords" content="{{ meta_keywords join=', ' }}">
 {{ /if }}
-<link rel="canonical" href="{{ canonical_url or permalink }}">
 {{ if auto_alternate_locales }}
 {{ auto_alternate_locales }}
 <link rel="alternate" hreflang="{{ locale }}" href="{{ url }}">
@@ -48,7 +56,6 @@
 <meta property="og:description" content="{{ facebook_description or meta_description }}">
 <meta property="og:type" content="website">
 <meta property="og:locale" content="{{ locale }}">
-<meta property="og:url" content="{{ canonical_url or permalink }}">
 {{ if calculated_facebook_image }}
 {{ asset:calculated_facebook_image }}
 <meta property="og:image" content="{{ permalink }}">


### PR DESCRIPTION
Pagination variables should be included in the canonical URL, this PR whitelists the `page` variable used by statamic pagination. Override it with the `canonical_url` field on the source page if you have a "View All" page where all entries will be listed without pagination