### PR TITLE
Add support for themed favicon

### DIFF
--- a/AardvarkSeo/fieldsets/general.yaml
+++ b/AardvarkSeo/fieldsets/general.yaml
@@ -36,6 +36,15 @@ fields:
             <li>A multiple of 48px square in dimensions</li>
             <li>A supported favicon file format, we recommend using `.png`</li>
           </ul>
+  favicon_type:
+    options:
+      global: Global favicon
+      themed: Light & dark mode favicon
+    inline: true
+    type: radio
+    instructions: 'Select whether you want to use a global favicon or a separate favicon for light and dark mode'
+    display: 'Global or themed favicon?'
+    default: global
   global_favicon:
     display: Global favicon
     type: assets
@@ -43,6 +52,28 @@ fields:
     restrict: false
     max_files: 1
     validate: image|mimes:png,jpg,jpeg,svg,gif,ico
+    show_when:
+      favicon_type: global
+  favicon_light_mode:
+    display: Light mode favicon
+    type: assets
+    folder: seo
+    restrict: false
+    max_files: 1
+    validate: image|mimes:png,jpg,jpeg,svg,gif,ico
+    width: 50
+    show_when:
+      favicon_type: themed
+  favicon_dark_mode:
+    display: Dark mode favicon
+    type: assets
+    folder: seo
+    restrict: false
+    max_files: 1
+    validate: image|mimes:png,jpg,jpeg,svg,gif,ico
+    width: 50
+    show_when:
+      favicon_type: themed
   knowledge_graph:
     type: section
     display: 'Knowledge Graph Data'
@@ -92,4 +123,3 @@ fields:
     is_site: true
     instructions: 'Prevent indexing across the entire site'
     display: 'No Index'
-

--- a/AardvarkSeo/resources/views/tags/aardvark-seo-head.html
+++ b/AardvarkSeo/resources/views/tags/aardvark-seo-head.html
@@ -36,10 +36,24 @@
 {{ /if }}
 
 {{# Favicon tag #}}
-{{ if global_favicon }}
+{{ if favicon_type === 'global' && global_favicon }}
   {{ asset:global_favicon }}
     <link rel="shortcut icon" href="{{ permalink }}">
   {{ /asset:global_favicon }}
+{{ elseif favicon_type === 'themed' }}
+  {{ if favicon_light_mode }}
+    {{ asset:favicon_light_mode }}
+      <link rel="shortcut icon" type="image/png" media="(prefers-color-scheme:light)" href="{{ permalink }}">
+    {{ /asset:favicon_light_mode }}
+  {{ /if }}
+  {{ if favicon_dark_mode }}
+    {{ asset:favicon_dark_mode }}
+      <link rel="shortcut icon" type="image/png" media="(prefers-color-scheme:dark)" href="{{ permalink }}">
+    {{ /asset:favicon_dark_mode }}
+  {{ /if }}
+  {{ if favicon_light_mode && favicon_dark_mode }}
+    <script src="https://unpkg.com/favicon-switcher@1.2.2/dist/index.js" crossorigin="anonymous" type="application/javascript"></script>
+  {{ /if }}
 {{ /if }}
 
 {{# Facebook OG tags #}}


### PR DESCRIPTION
This adds support for separate favicons for light and dark mode. A simple script is detecting whether the browser is in light or dark mode and serves the right icon.

To proof the concept, it's currently using [this script ](https://github.com/rumkin/favicon-switcher). I'd probably add the script as part of the addon itself, to not rely on a CDN. [Here's an article](https://dev.to/rumkin/smart-web-design-part-i-light-dark-mode-favicon-31f0) that further describes the concept.

I'd love to see this merged. Let me know if I can further assist you.