### PR TITLE
#15 Allow non Super Users access to the SEO settings menu

### DIFF
--- a/AardvarkSeo/AardvarkSeoListener.php
+++ b/AardvarkSeo/AardvarkSeoListener.php
@@ -13,6 +13,7 @@ use Statamic\API\File;
 use Statamic\API\Nav;
 use Statamic\API\YAML;
 use Statamic\API\Config;
+use Statamic\API\Role;
 use Statamic\API\User;
 use Statamic\Extend\Listener;
 
@@ -45,9 +46,11 @@ class AardvarkSeoListener extends Listener
      */
     public function addSeoNavItems($nav)
     {
-        // Only super-users can access this
+        // Only super-users and users with the role seo can access this
         $user = User::getCurrent();
-        if ($user->isSuper()) {
+		$role = Role::whereHandle('seo');
+
+        if ($user->hasRole($role) || $user->isSuper()) {
             $seo_section = Nav::item('aardvark-seo')->title('SEO')->route('aardvark-seo')->icon('line-graph');
 
             $errors = AardvarkController::getErrors();

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -8,6 +8,22 @@ There is only one setting that will need to be configured after installation, we
 
 Once successfully installed a new 'SEO' item will appear in the control panel navigation - under 'Tools'. This is where you can manage most of the global SEO settings for the site.
 
+### Allowing non Super Users to access settings
+
+On installing, any user with edit access to the relevant pages and collections will be able to see and edit the settings for pages and entries under the SEO tab. However, by default, only users with the `Super User` permission will be able to access the SEO settings tab under the Tools submenu. If you wish to give users who need access to the SEO settings page, but do need – or should not have – Super User permissions (for example, members of your SEO team), then you will need to do the following:
+
+1. In the left hand menu of the control panel, click on `Users`.
+2. Click on `User Roles` when it appears.
+3. In the top right hand corner of the screen, click `Create Role`.
+4. In the title field, enter `SEO`.
+5. In slug, enter `seo`.
+6. In the next box, tick `Access Control Panel` under General.
+7. Click `Save`.
+
+Once you've done this, you can then add the new SEO role to any user or user group you wish to be able to access the SEO settings.
+
+Note: We recommend having a separate role for allowing editing access to pages and entries. Not every user who needs access to the SEO settings will need access to edit pages and entries, and vice-versa.
+
 ### Tags
 
 Getting your site's SEO data onto the page relies on a few tags being present in your theme templates:


### PR DESCRIPTION
Hey @AndrewHaine.

We've had to make this change to the Aardvark SEO addon in order to allow some members of our SEO team with access to the settings page under Tools, without giving them access to everything else.

Obviously, as you've noted in #15, there's no way natively give permissions to an addon like there is with first class functions like Forms and the Updater. However, by adding a role check, and getting the developer to create a new role (in this case, SEO), we can check for the presence of that role and allow permission to access it.

It's not as nice as a native approach would be, but it's a relatively small amount of manual work to resolve the lack of native functionality.

I've updated both the listener with the required code, and the docs to explain to developers how to configure it.