### PR TITLE
Set default 404 page title

### DIFF
--- a/src/Parsers/PageDataParser.php
+++ b/src/Parsers/PageDataParser.php
@@ -148,6 +148,10 @@ class PageDataParser
             return $data->get('meta_title');
         }
 
+        if ($data->get('response_code') === 404) {
+            $data->put('title', '404');
+        }
+
         $storage = self::getSettingsBlueprintWithValues($ctx, 'general', new GeneralSettingsBlueprint());
 
         return implode(' ', [


### PR DESCRIPTION
This PR addresses issue #65. It simply checks for a `response_code` of `404` and sets the title accordingly.

This could be further enhanced by allowing the user to change the 404 title in the General Settings.