### PR TITLE
Allow for the meta_description field to be parsed

### DIFF
--- a/src/Blueprints/CP/DefaultsSettingsBlueprint.php
+++ b/src/Blueprints/CP/DefaultsSettingsBlueprint.php
@@ -162,6 +162,7 @@ class DefaultsSettingsBlueprint implements AardvarkBlueprint
                             'field' => [
                                 'type' => 'textarea',
                                 'display' => __('aardvark-seo::onpage.fields.twitter_description.display'),
+                                'antlers' => true,
                                 'if' => [
                                     'override_twitter_settings' => 'equals true',
                                 ],

--- a/src/Blueprints/CP/DefaultsSettingsBlueprint.php
+++ b/src/Blueprints/CP/DefaultsSettingsBlueprint.php
@@ -39,6 +39,7 @@ class DefaultsSettingsBlueprint implements AardvarkBlueprint
                                 'type' => 'aardvark_seo_meta_description',
                                 'display' => __('aardvark-seo::onpage.fields.meta_description.display'),
                                 'localizable' => true,
+                                'antlers' => true,
                             ],
                         ],
                         [
@@ -113,6 +114,7 @@ class DefaultsSettingsBlueprint implements AardvarkBlueprint
                                 'type' => 'textarea',
                                 'display' => __('aardvark-seo::onpage.fields.og_description.display'),
                                 'localizable' => true,
+                                'antlers' => true,
                             ],
                         ],
                         [

--- a/src/Blueprints/CP/OnPageSeoBlueprint.php
+++ b/src/Blueprints/CP/OnPageSeoBlueprint.php
@@ -39,6 +39,7 @@ class OnPageSeoBlueprint implements AardvarkBlueprint
                                 'type' => 'aardvark_seo_meta_description',
                                 'display' => __('aardvark-seo::onpage.fields.meta_description.display'),
                                 'localizable' => true,
+                                'antlers' => true,
                             ],
                         ],
                         [
@@ -209,6 +210,7 @@ class OnPageSeoBlueprint implements AardvarkBlueprint
                                 'type' => 'textarea',
                                 'display' => __('aardvark-seo::onpage.fields.og_description.display'),
                                 'localizable' => true,
+                                'antlers' => true,
                             ],
                         ],
                         [

--- a/src/Blueprints/CP/OnPageSeoBlueprint.php
+++ b/src/Blueprints/CP/OnPageSeoBlueprint.php
@@ -259,6 +259,7 @@ class OnPageSeoBlueprint implements AardvarkBlueprint
                                 'type' => 'textarea',
                                 'display' => __('aardvark-seo::onpage.fields.twitter_description.display'),
                                 'localizable' => true,
+                                'antlers' => true,
                                 'if' => [
                                     'override_twitter_settings' => 'equals true',
                                 ],


### PR DESCRIPTION
Just a config update on the blueprint to include `'antlers' => true,` will allow the field to be parsed making it super easy to set a field from the entry