### PR TITLE
Show SEO fields when content is created

### DIFF
--- a/src/Listeners/AppendEntrySeoFieldsListener.php
+++ b/src/Listeners/AppendEntrySeoFieldsListener.php
@@ -5,6 +5,7 @@ namespace WithCandour\AardvarkSeo\Listeners;
 use Statamic\Events\EntryBlueprintFound;
 use WithCandour\AardvarkSeo\Blueprints\CP\OnPageSeoBlueprint;
 use WithCandour\AardvarkSeo\Listeners\Contracts\SeoFieldsListener;
+use Statamic\Support\Str;
 
 class AppendEntrySeoFieldsListener implements SeoFieldsListener
 {
@@ -16,8 +17,8 @@ class AppendEntrySeoFieldsListener implements SeoFieldsListener
     public function handle(EntryBlueprintFound $event)
     {
         // We don't want the SEO fields to get added to the blueprint editor
-        if (empty($event->entry)) {
-            return null;
+        if (Str::contains(request()->url(), '/blueprints/') || app()->runningInConsole()) {
+            return;
         }
 
         $handle = $event->blueprint->namespace();

--- a/src/Listeners/AppendTermSeoFieldsListener.php
+++ b/src/Listeners/AppendTermSeoFieldsListener.php
@@ -5,6 +5,7 @@ namespace WithCandour\AardvarkSeo\Listeners;
 use Statamic\Events\TermBlueprintFound;
 use WithCandour\AardvarkSeo\Blueprints\CP\OnPageSeoBlueprint;
 use WithCandour\AardvarkSeo\Listeners\Contracts\SeoFieldsListener;
+use Statamic\Support\Str;
 
 class AppendTermSeoFieldsListener implements SeoFieldsListener
 {
@@ -16,8 +17,8 @@ class AppendTermSeoFieldsListener implements SeoFieldsListener
     public function handle(TermBlueprintFound $event)
     {
         // We don't want the SEO fields to get added to the blueprint editor
-        if (empty($event->term)) {
-            return null;
+        if (Str::contains(request()->url(), '/blueprints/') || app()->runningInConsole()) {
+            return;
         }
 
         $handle = $event->blueprint->namespace();


### PR DESCRIPTION
Improve how SEO fields are added to entry/term blueprints so that they are available when the item is initially created]