### PR TITLE
Fix locale og tag

### DIFF
--- a/resources/views/tags/head.antlers.html
+++ b/resources/views/tags/head.antlers.html
@@ -46,7 +46,11 @@
     <meta property="og:title" content="{{ og_title or calculated_title }}">
     <meta property="og:description" content="{{ og_description or meta_description }}">
     <meta property="og:type" content="website">
-    <meta property="og:locale" content="{{ site:locale | aardvark_parse_locale }}">
+    {{ locales }}
+        {{ if is_current }}
+            <meta property="og:locale" content="{{ locale:full | aardvark_parse_locale }}">
+        {{ /if }}
+    {{ /locales }}    
     {{ if calculated_og_image }}
     {{ calculated_og_image }}
     <meta property="og:image" content="{{ permalink }}">


### PR DESCRIPTION
We dont use antlers directly but when we call the Tag with
```php
     $html = (new AardvarkSeoTags())->setContext($page)->setParameters([])->head();
```
Everything seems te load except the locale tag. This seems to fix the problem. Not sure if this happens when you use the tag the normal way. 