### PR TITLE
Fix defaults search for repos

### DIFF
--- a/src/Parsers/PageDataParser.php
+++ b/src/Parsers/PageDataParser.php
@@ -72,10 +72,10 @@ class PageDataParser
 
         switch ($type) {
             case 'taxonomies':
-                $repo = $ctx->get('taxonomy')->value();
+                $repo = $ctx->get('taxonomy')?->value();
                 break;
             case 'collections':
-                $repo = $ctx->get('collection')->value();
+                $repo = $ctx->get('collection')?->value();
                 break;
             default:
                 $repo = null;

--- a/src/Parsers/PageDataParser.php
+++ b/src/Parsers/PageDataParser.php
@@ -72,10 +72,10 @@ class PageDataParser
 
         switch ($type) {
             case 'taxonomies':
-                $repo = $ctx->get('taxonomy');
+                $repo = $ctx->get('taxonomy')->value();
                 break;
             case 'collections':
-                $repo = $ctx->get('collection');
+                $repo = $ctx->get('collection')->value();
                 break;
             default:
                 $repo = null;


### PR DESCRIPTION
This fixes the default search which is currently returning the wrong file path (it's returning 'collections_collection.yaml' or 'taxonomies_taxonomy.yaml')