### PR TITLE
Include secure URL on og:image

### DIFF
--- a/resources/views/tags/head.antlers.html
+++ b/resources/views/tags/head.antlers.html
@@ -47,7 +47,8 @@
     <meta property="og:locale" content="{{ site:locale | aardvark_parse_locale }}">
     {{ if calculated_og_image }}
     {{ calculated_og_image }}
-    <meta property="og:image" content="{{ permalink }}">
+    <meta property="og:image" content="{{ permalink replace='https|http' }}">
+    <meta property="og:image:secure_url" content="{{ permalink }}">
     <meta property="og:image:width" content="{{ width }}">
     <meta property="og:image:height" content="{{ height }}">
     <meta property="og:image:alt" content="{{ alt }}">


### PR DESCRIPTION
Seems to be a bug on Facebook debugger in some instances where it will not show the https version of an image.