### PR TITLE
Add Default Locale Option to enable x-default

### DIFF
--- a/resources/lang/en/general.php
+++ b/resources/lang/en/general.php
@@ -57,6 +57,13 @@ return [
             'display' => 'No Index',
             'instruct' => 'Prevent indexing across the entire site.',
         ],
+        'default_locale_section' => [
+            'display' => 'Default Locale',
+            'instruct' => 'Select a locale to use as a default hreflang tag (see [https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages](https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages)).',
+        ],
+        'default_locale' => [
+            'display' => 'Default Locale',
+        ],
     ]
 
 ];

--- a/resources/views/tags/hreflang.antlers.html
+++ b/resources/views/tags/hreflang.antlers.html
@@ -1,5 +1,8 @@
 {{ if hreflang_tags }}
     {{ hreflang_tags }}
+        {{ if default }}
+        <link rel='alternate' href="{{ url }}" hreflang="x-default" >
+        {{ /if }}
         <link rel='alternate' href="{{ url }}" hreflang="{{ locale | aardvark_parse_locale }}" >
     {{ /hreflang_tags }}
 {{ /if }}

--- a/src/Blueprints/CP/GeneralSettingsBlueprint.php
+++ b/src/Blueprints/CP/GeneralSettingsBlueprint.php
@@ -171,7 +171,6 @@ class GeneralSettingsBlueprint implements AardvarkBlueprint
                                 'type' => 'sites',
                                 'max_items' => 1,
                                 'display' => __('aardvark-seo::general.fields.default_locale.display'),
-                                'instructions' => __('aardvark-seo::general.fields.default_locale.instruct'),
                             ],
                         ],
                     ],

--- a/src/Blueprints/CP/GeneralSettingsBlueprint.php
+++ b/src/Blueprints/CP/GeneralSettingsBlueprint.php
@@ -157,6 +157,23 @@ class GeneralSettingsBlueprint implements AardvarkBlueprint
                                 'instructions' => __('aardvark-seo::general.fields.no_index_site.instruct'),
                             ],
                         ],
+                        [
+                            'handle' => 'default_locale_section',
+                            'field' => [
+                                'type' => 'section',
+                                'display' => __('aardvark-seo::general.fields.default_locale_section.display'),
+                                'instructions' => __('aardvark-seo::general.fields.default_locale_section.instruct'),
+                            ],
+                        ],
+                        [
+                            'handle' => 'default_locale',
+                            'field' => [
+                                'type' => 'sites',
+                                'max_items' => 1,
+                                'display' => __('aardvark-seo::general.fields.default_locale.display'),
+                                'instructions' => __('aardvark-seo::general.fields.default_locale.instruct'),
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/src/Modifiers/ParseLocaleModifier.php
+++ b/src/Modifiers/ParseLocaleModifier.php
@@ -11,6 +11,10 @@ class ParseLocaleModifier extends Modifier
 
     public static function index($value)
     {
+        if($value == 'x-default') {
+            return $value;
+        }
+        
         $parsed = preg_replace('/\.utf8/i', '', $value);
 
         // Convert to W3C

--- a/src/Modifiers/ParseLocaleModifier.php
+++ b/src/Modifiers/ParseLocaleModifier.php
@@ -11,7 +11,7 @@ class ParseLocaleModifier extends Modifier
 
     public static function index($value)
     {
-        if($value == 'x-default') {
+        if($value === 'x-default') {
             return $value;
         }
         

--- a/src/Tags/AardvarkSeoTags.php
+++ b/src/Tags/AardvarkSeoTags.php
@@ -126,7 +126,7 @@ class AardvarkSeoTags extends Tags
             }
 
             return null;
-        }, []) ->filter();
+        }, [])->filter();
 
         if (!empty($alternates)) {
             return view('aardvark-seo::tags.hreflang', [

--- a/src/Tags/AardvarkSeoTags.php
+++ b/src/Tags/AardvarkSeoTags.php
@@ -101,24 +101,32 @@ class AardvarkSeoTags extends Tags
             return null;
         }
 
+
+        $defaultLocale = $ctx->get('aardvark_general_settings')['default_locale'];
+
+        if ($defaultLocale instanceof \Statamic\Fields\Value) {
+            $defaultLocale = $defaultLocale->value();
+        }
+
         $sites_by_handle = Site::all()->reduce(function($sites, $site) {
             $sites[$site->handle()] = $site;
             return $sites;
         }, []);
 
-        $alternates = $data->sites()->map(function ($handle) use ($data, $sites_by_handle) {
+        $alternates = $data->sites()->map(function ($handle) use ($data, $sites_by_handle, $defaultLocale) {
             $localized_data = $data->in($handle);
 
             if(!empty($localized_data) && $localized_data->published()) {
                 $site = $sites_by_handle[$handle];
                 return [
                     'url' => $localized_data->absoluteUrl(),
-                    'locale' => $site->locale()
+                    'locale' => $site->locale(),
+                    'default' => !empty($defaultLocale) ? $site->handle == $defaultLocale->handle : false,
                 ];
             }
 
             return null;
-        }, [])->filter();
+        }, []) ->filter();
 
         if (!empty($alternates)) {
             return view('aardvark-seo::tags.hreflang', [

--- a/src/Tags/AardvarkSeoTags.php
+++ b/src/Tags/AardvarkSeoTags.php
@@ -121,7 +121,7 @@ class AardvarkSeoTags extends Tags
                 return [
                     'url' => $localized_data->absoluteUrl(),
                     'locale' => $site->locale(),
-                    'default' => !empty($defaultLocale) ? $site->handle == $defaultLocale->handle : false,
+                    'default' => !empty($defaultLocale) ? $site->handle === $defaultLocale->handle : false,
                 ];
             }
 


### PR DESCRIPTION
Added a new general config option to select a site as the default locale, this will then add the x-default hreflang tags to the html.

<img width="942" alt="Screenshot 2024-01-18 at 14 44 46" src="https://github.com/WithCandour/statamic-aardvark-seo/assets/8768709/2bc4c8a4-1d13-42ea-b7e7-c167c2f57376">


See: [https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages](https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages) 

Implements: https://github.com/WithCandour/statamic-aardvark-seo/issues/82

Please let me know if you would like this done in a different way or need any amendments, this is a first draft just to get the ball rolling.

