### PR TITLE
Excluding future entries from the sitemap

### DIFF
--- a/src/Sitemaps/Sitemap.php
+++ b/src/Sitemaps/Sitemap.php
@@ -91,6 +91,7 @@ class Sitemap
                     ->where('collection', $this->handle)
                     ->where('site', Site::current()->handle())
                     ->where('redirect', '=', null)
+                    ->where('date', '<=', now()) // Exclude future posts by checking the post date is less than or equal to today
                     ->get();
                 break;
             case 'taxonomy':


### PR DESCRIPTION
This update excludes future posts by checking if the post date is less than or equal to today.