### PR TITLE
Localization Issues

### DIFF
--- a/resources/js/components/fieldtypes/GooglePreviewFieldtype.vue
+++ b/resources/js/components/fieldtypes/GooglePreviewFieldtype.vue
@@ -16,21 +16,33 @@
 
         computed: {
             previewParts() {
+
                 const state = this.$store.state.publish[this.storeName];
+
                 const {
                     meta_title,
                     meta_description,
                     slug,
                     title,
                 } = state.values;
+
                 const {
                     site_name,
                     site_url,
                     title_separator,
+                    default_locale,
                 } = this.meta;
 
+                // Initialise pageTitle with meta_title if available, otherwise combine title with site name and separator.
+                let pageTitle = meta_title || `${title}${site_name ? ` ${title_separator} ${site_name}` : ''}`;
+
+                // Override pageTitle for non-default locales without a localised meta_title, using title and optionally site name and separator.
+                if (state && state.localizedFields && default_locale !== state.site && !state.localizedFields.includes('meta_title')) {
+                    pageTitle = `${title}${site_name ? ` ${title_separator} ${site_name}` : ''}`;
+                }
+
                 return {
-                    title: meta_title || `${title} ${title_separator} ${site_name}`,
+                    title: pageTitle,
                     url: `${site_url}/${slug}`,
                     description: meta_description
                 }

--- a/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
+++ b/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
@@ -2,7 +2,7 @@
     <div class="meta-field-validator__outer">
         <div class="meta-field-validator__field-container">
             <div class="input-group">
-                <input :value="value" @input="update($event.target.value)" @keyup="handleKeyUp" type="text" :name="name" :id="id" :placeholder="generatePlaceholder()" class="input-text" />
+                <input :value="generateTitle(value)" @input="update($event.target.value)" @keyup="handleKeyUp" type="text" :name="name" :id="id" :placeholder="generatePlaceholder()" class="input-text" />
             </div>
             <progress max="70" :value="contentLength" :class="'meta-field-validator__progress meta-field-validator__progress--' + validation.step" />
         </div>
@@ -21,7 +21,30 @@
         methods: {
             generatePlaceholder() {
                 const state = this.$store.state.publish[this.storeName];
-                return `${state.values.title || ''} ${this.meta.title_separator} ${this.meta.site_name}`
+                return this.meta.site_name
+                    ? `${state.values.title || ''} ${this.meta.title_separator} ${this.meta.site_name}`
+                    : state.values.title || '';
+            },
+            /**
+             * Generates the title based on localisation fields.
+             * If the current site is not the default locale and the 'meta_title' is not localised,
+             * it returns an empty string; otherwise, it returns the provided value.
+             *
+             * @param {string} value - The original title value to potentially return.
+             * @return {string} - The localised title or an empty string.
+             */
+            generateTitle(value) {
+                // Access the publish state from the Vuex store
+                const state = this.$store.state.publish[this.storeName];
+
+                // Check if the state exists, has localizedFields, and if the current site is not the default locale
+                if (state && state.localizedFields && this.meta.default_locale !== state.site) {
+                    // Return the value only if 'meta_title' is a localised field
+                    return state.localizedFields.includes('meta_title') ? value : '';
+                }
+
+                // Return the provided value as default
+                return value;
             },
             validateMeta(length) {
                 let validation;

--- a/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
+++ b/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
@@ -21,13 +21,9 @@
 
         data() {
             return {
-                isFocussed: false,
+                isFocused: false,
                 hasSyncedJustChanged: false,
             };
-        },
-
-        created() {
-            this.processed = 0; // This is a plain JavaScript property, not a reactive data property
         },
 
         computed: {
@@ -59,7 +55,7 @@
 
         methods: {
             toggleFocus(focusState) {
-                this.isFocussed = focusState;
+                this.isFocused = focusState;
             },
             generatePlaceholder() {
                 const state = this.$store.state.publish[this.storeName];
@@ -77,20 +73,18 @@
              */
             generateTitle(value) {
 
-                this.processed++;
-
                 // Access the publish state from the Vuex store
                 const state = this.$store.state.publish[this.storeName];
 
                 if(state && state.localizedFields && this.meta.default_locale !== state.site) {
 
-                    if (!this.isSynced && this.hasSyncedJustChanged && !this.isFocussed) {
+                    if (!this.isSynced && this.hasSyncedJustChanged && !this.isFocused) {
                         this.hasSyncedJustChanged = false;
                         state.values.meta_title = state.values.title;
                         return state.values.title;
                     }
 
-                    if(this.isSynced && this.hasSyncedJustChanged && !this.isFocussed && this.processed > 0) {
+                    if(this.isSynced && this.hasSyncedJustChanged && !this.isFocused) {
                         state.values.meta_title = '';
                     }
 

--- a/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
+++ b/resources/js/components/fieldtypes/MetaTitleFieldtype.vue
@@ -66,29 +66,37 @@
             /**
              * Generates the title based on localisation fields.
              * If the current site is not the default locale and the 'meta_title' is not localised,
-             * it returns an empty string; otherwise, it returns the provided value.
+             * it returns an empty string; otherwise, it returns the provided value. It also handles the sync logic by updating
+             * the meta title based on the fields current sync state.
              *
              * @param {string} value - The original title value to potentially return.
-             * @return {string} - The localised title or an empty string.
+             * @return {string} - The localised title based on the current site's locale and field's sync state, or an empty string.
              */
             generateTitle(value) {
-
                 // Access the publish state from the Vuex store
                 const state = this.$store.state.publish[this.storeName];
 
+                // Check if state is defined, and if the current site has localizedFields and is not the default locale.
                 if(state && state.localizedFields && this.meta.default_locale !== state.site) {
 
+                    // If the field is not synced and has just been changed and is not currently focused,
+                    // reset the hasSyncedJustChanged flag and update the meta title to match the page title.
                     if (!this.isSynced && this.hasSyncedJustChanged && !this.isFocused) {
                         this.hasSyncedJustChanged = false;
+                        // ToDo: Best practice: dispatch an action or commit a mutation instead
                         state.values.meta_title = state.values.title;
                         return state.values.title;
                     }
 
+                    // If the field is synced and has just been changed and is not currently focused, clear the meta title.
                     if(this.isSynced && this.hasSyncedJustChanged && !this.isFocused) {
+                        // ToDo: Best practice: dispatch an action or commit a mutation instead
                         state.values.meta_title = '';
                     }
 
+                    // If the field is synced and has not just changed, ensure the meta title remains cleared.
                     if(this.isSynced && !this.hasSyncedJustChanged) {
+                        // ToDo: Best practice: dispatch an action or commit a mutation instead
                         state.values.meta_title = '';
                     }
 
@@ -99,6 +107,7 @@
                 // Return the provided value as default
                 return value;
             },
+
             validateMeta(length) {
                 let validation;
                 switch (true) {

--- a/src/Fieldtypes/AardvarkSeoGooglePreviewFieldtype.php
+++ b/src/Fieldtypes/AardvarkSeoGooglePreviewFieldtype.php
@@ -21,6 +21,7 @@ class AardvarkSeoGooglePreviewFieldtype extends Fieldtype
             'site_name' => $data->get('site_name', ''),
             'site_url' => $site->absoluteUrl(),
             'title_separator' => $data->get('title_separator', '|'),
+            'default_locale' => Site::default()->handle(),
         ];
     }
 }

--- a/src/Fieldtypes/AardvarkSeoMetaTitleFieldtype.php
+++ b/src/Fieldtypes/AardvarkSeoMetaTitleFieldtype.php
@@ -13,13 +13,15 @@ class AardvarkSeoMetaTitleFieldtype extends Fieldtype
     /**
      * Load the global seo settings from storage
      */
-    public function preload()
+    public function preload(): array
     {
         $site = Site::selected();
         $data = AardvarkStorage::getYaml('general', $site, true);
+
         return [
             'site_name' => $data->get('site_name', ''),
             'title_separator' => $data->get('title_separator', '|'),
+            'default_locale' => Site::default()->handle(),
         ];
     }
 }


### PR DESCRIPTION
- The reported undesired behavior in #60 is actually native behavior.
- Had to alter the native Statamic localised field behaviour.
- It was not possible to detect when the field was synced or de-synced, as events are not passed down to this component (at least I couldn't find a solution to this) – might worth submitting this as a feature request.
- Had to write tests to check this state instead.
- If the field is de-synced and not focused, set `meta_title` to `title`.
- If the field is synced and not focused, set `meta_title` to `` (an empty string).
- Edge case: If the field is synced, but the sync status has not changed, set `meta_title` to `` (an empty string).
- Finally, if `localizedFields` includes `meta_title`, return the `value`; otherwise, return `` (an empty string).
- Please run further tests to detect other edge cases.
- Have tested on a multi-site installation, but requires testing on a single-site installation also.
- Not too familiar with Vue, but it has been determined that modifying the Vuex state outside of mutations/actions isn't best practice, so an alternative solution to `state.values.meta_title = state.values.title` may be necessary, for example.