### PR TITLE
Ensure that aardvark_general_settings not null

### DIFF
--- a/src/Tags/AardvarkSeoTags.php
+++ b/src/Tags/AardvarkSeoTags.php
@@ -101,6 +101,9 @@ class AardvarkSeoTags extends Tags
             return null;
         }
 
+        if (!$ctx->get('aardvark_general_settings')){
+            return null;
+        }
 
         $defaultLocale = $ctx->get('aardvark_general_settings')['default_locale'];
 
@@ -172,6 +175,10 @@ class AardvarkSeoTags extends Tags
     {
         $ctx = collect($this->context);
         $attrs = [];
+
+        if (!$ctx->get('aardvark_general_settings')){
+            return null;
+        }
 
         $global_no_index = $ctx->get('aardvark_general_settings')['no_index_site'];
 


### PR DESCRIPTION
Fixes bug when aardvark_general_settings empty, and it tries to get some fields on empty array. 
ErrorException: 'Trying to access array offset on value of type null'