### PR TITLE
Collection defaults only work on taxonomies and "pages" collection

### DIFF
--- a/src/Parsers/PageDataParser.php
+++ b/src/Parsers/PageDataParser.php
@@ -84,7 +84,7 @@ class PageDataParser
                 }
                 break;
             case 'collections':
-                $repo = $ctx->get('taxonomy');
+                $repo = $ctx->get('collection');
                 if ($repo instanceof \Statamic\Fields\Value) {
                     $repo = $repo->value();
                 }


### PR DESCRIPTION
Fixes an issue where `getDefaults` was looking for the wrong defaults file name when a collection was named anything other than "pages".

`getDefaults` was looking for the `taxonomy` field on collection entries, but defaults are saved in the format of "collections_{COLLECTION_HANDLE}" (not "collections_{TAXONOMY_HANDLE}").